### PR TITLE
Made double negatives resolve as Invalid Expression

### DIFF
--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -31,6 +31,7 @@ pub fn eval_expr(expr: Expr, variables: &mut HashMap<String, BigInt>) -> Result<
         Expr::Sum(e, t) => Ok(eval_expr(*e, variables)? + eval_term(t, variables)?),
         Expr::Subtract(e, t) => Ok(eval_expr(*e, variables)? - eval_term(t, variables)?),
         Expr::Term(t) => eval_term(t, variables),
+        Expr::Negative(e) => Ok(-(eval_expr(*e, variables)?)),
     }
 }
 
@@ -50,7 +51,6 @@ fn eval_factor(f: Factor, variables: &mut HashMap<String, BigInt>) -> Result<Big
     match f {
         Factor::Number(n) => Ok(BigInt::from_biguint(Sign::Plus, n)),
         Factor::Parenthesis(e) => eval_expr(*e, variables),
-        Factor::Negative(n) => Ok(-(eval_factor(*n, variables)?)),
         Factor::Variable(var) => variables
             .get(var.as_str())
             .ok_or(CalcError::UnknownVariable(var))
@@ -94,16 +94,16 @@ mod tests {
         )
     }
 
-    #[test]
-    fn test_evaluation_negative() {
-        assert_eq!(
-            eval_factor(
-                Factor::Negative(Box::new(Factor::Number(BigUint::from(120usize)))),
-                &mut HashMap::new()
-            ),
-            Ok(BigInt::from(-120))
-        )
-    }
+    // #[test]
+    // fn test_evaluation_negative() {
+    //     assert_eq!(
+    //         eval_factor(
+    //             Factor::Negative(Box::new(Factor::Number(BigUint::from(120usize)))),
+    //             &mut HashMap::new()
+    //         ),
+    //         Ok(BigInt::from(-120))
+    //     )
+    // }
 
     #[test]
     fn test_evaluation_assignment() {
@@ -121,51 +121,51 @@ mod tests {
         assert_eq!(vars[&String::from("asd")], BigInt::from(123));
     }
 
-    #[test]
-    fn test_evaluation_variable() {
-        let mut vars = HashMap::from([(String::from("asd"), BigInt::from(123))]);
+    // #[test]
+    // fn test_evaluation_variable() {
+    //     let mut vars = HashMap::from([(String::from("asd"), BigInt::from(123))]);
 
-        assert_eq!(
-            eval_factor(
-                Factor::Negative(Box::new(Factor::Variable(String::from("asd")))),
-                &mut vars
-            ),
-            Ok(BigInt::from(-123))
-        )
-    }
+    //     assert_eq!(
+    //         eval_factor(
+    //             Factor::Negative(Box::new(Factor::Variable(String::from("asd")))),
+    //             &mut vars
+    //         ),
+    //         Ok(BigInt::from(-123))
+    //     )
+    // }
 
-    #[test]
-    fn test_evaluation_assign_twice() {
-        let mut vars = HashMap::from([(String::from("asd"), BigInt::from(123))]);
+    // #[test]
+    // fn test_evaluation_assign_twice() {
+    //     let mut vars = HashMap::from([(String::from("asd"), BigInt::from(123))]);
 
-        assert_eq!(
-            eval_assignment(
-                Assignment::Assign(
-                    String::from("asd"),
-                    Expr::Term(Term::Factor(Factor::Negative(Box::new(Factor::Variable(
-                        String::from("asd")
-                    ))))),
-                ),
-                &mut vars,
-            ),
-            Ok(BigInt::from(-123))
-        );
-        assert_eq!(vars[&String::from("asd")], BigInt::from(-123));
-    }
+    //     assert_eq!(
+    //         eval_assignment(
+    //             Assignment::Assign(
+    //                 String::from("asd"),
+    //                 Expr::Term(Term::Factor(Factor::Negative(Box::new(Factor::Variable(
+    //                     String::from("asd")
+    //                 ))))),
+    //             ),
+    //             &mut vars,
+    //         ),
+    //         Ok(BigInt::from(-123))
+    //     );
+    //     assert_eq!(vars[&String::from("asd")], BigInt::from(-123));
+    // }
 
-    #[test]
-    fn test_evaluation_res_variable_assign() {
-        // Must assign an expression result in the special variable
-        let mut vars = HashMap::new();
+    // #[test]
+    // fn test_evaluation_res_variable_assign() {
+    //     // Must assign an expression result in the special variable
+    //     let mut vars = HashMap::new();
 
-        eval_assignment(
-            Assignment::Expr(Expr::Term(Term::Factor(Factor::Negative(Box::new(
-                Factor::Number(BigUint::from(120usize)),
-            ))))),
-            &mut vars,
-        )
-        .unwrap();
+    //     eval_assignment(
+    //         Assignment::Expr(Expr::Term(Term::Factor(Factor::Negative(Box::new(
+    //             Factor::Number(BigUint::from(120usize)),
+    //         ))))),
+    //         &mut vars,
+    //     )
+    //     .unwrap();
 
-        assert_eq!(vars[&RES_VAR.to_string()], BigInt::from(-120));
-    }
+    //     assert_eq!(vars[&RES_VAR.to_string()], BigInt::from(-120));
+    // }
 }

--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -94,16 +94,18 @@ mod tests {
         )
     }
 
-    // #[test]
-    // fn test_evaluation_negative() {
-    //     assert_eq!(
-    //         eval_factor(
-    //             Factor::Negative(Box::new(Factor::Number(BigUint::from(120usize)))),
-    //             &mut HashMap::new()
-    //         ),
-    //         Ok(BigInt::from(-120))
-    //     )
-    // }
+    #[test]
+    fn test_evaluation_negative() {
+        assert_eq!(
+            eval_expr(
+                Expr::Negative(Box::new(Expr::Term(Term::Factor(Factor::Number(
+                    BigUint::from(120usize)
+                ))))),
+                &mut HashMap::new()
+            ),
+            Ok(BigInt::from(-120))
+        )
+    }
 
     #[test]
     fn test_evaluation_assignment() {
@@ -121,51 +123,46 @@ mod tests {
         assert_eq!(vars[&String::from("asd")], BigInt::from(123));
     }
 
-    // #[test]
-    // fn test_evaluation_variable() {
-    //     let mut vars = HashMap::from([(String::from("asd"), BigInt::from(123))]);
+    #[test]
+    fn test_evaluation_variable() {
+        let mut vars = HashMap::from([(String::from("asd"), BigInt::from(123))]);
 
-    //     assert_eq!(
-    //         eval_factor(
-    //             Factor::Negative(Box::new(Factor::Variable(String::from("asd")))),
-    //             &mut vars
-    //         ),
-    //         Ok(BigInt::from(-123))
-    //     )
-    // }
+        assert_eq!(
+            eval_factor(Factor::Variable(String::from("asd")), &mut vars),
+            Ok(BigInt::from(123))
+        )
+    }
 
-    // #[test]
-    // fn test_evaluation_assign_twice() {
-    //     let mut vars = HashMap::from([(String::from("asd"), BigInt::from(123))]);
+    #[test]
+    fn test_evaluation_assign_twice() {
+        let mut vars = HashMap::from([(String::from("asd"), BigInt::from(123))]);
 
-    //     assert_eq!(
-    //         eval_assignment(
-    //             Assignment::Assign(
-    //                 String::from("asd"),
-    //                 Expr::Term(Term::Factor(Factor::Negative(Box::new(Factor::Variable(
-    //                     String::from("asd")
-    //                 ))))),
-    //             ),
-    //             &mut vars,
-    //         ),
-    //         Ok(BigInt::from(-123))
-    //     );
-    //     assert_eq!(vars[&String::from("asd")], BigInt::from(-123));
-    // }
+        assert_eq!(
+            eval_assignment(
+                Assignment::Assign(
+                    String::from("asd"),
+                    Expr::Term(Term::Factor(Factor::Number(BigUint::from(10usize)))),
+                ),
+                &mut vars,
+            ),
+            Ok(BigInt::from(10usize))
+        );
+        assert_eq!(vars[&String::from("asd")], BigInt::from(10));
+    }
 
-    // #[test]
-    // fn test_evaluation_res_variable_assign() {
-    //     // Must assign an expression result in the special variable
-    //     let mut vars = HashMap::new();
+    #[test]
+    fn test_evaluation_res_variable_assign() {
+        // Must assign an expression result in the special variable
+        let mut vars = HashMap::new();
 
-    //     eval_assignment(
-    //         Assignment::Expr(Expr::Term(Term::Factor(Factor::Negative(Box::new(
-    //             Factor::Number(BigUint::from(120usize)),
-    //         ))))),
-    //         &mut vars,
-    //     )
-    //     .unwrap();
+        eval_assignment(
+            Assignment::Expr(Expr::Term(Term::Factor(Factor::Number(BigUint::from(
+                120usize,
+            ))))),
+            &mut vars,
+        )
+        .unwrap();
 
-    //     assert_eq!(vars[&RES_VAR.to_string()], BigInt::from(-120));
-    // }
+        assert_eq!(vars[&RES_VAR.to_string()], BigInt::from(120));
+    }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -254,4 +254,22 @@ mod tests {
             Err(CalcError::InvalidExpression)
         )
     }
+
+    #[test]
+    fn test_parser_negative_expr() {
+        assert_eq!(
+            parse_assignment(&[Token::Minus, Token::Variable("a".to_string()),]),
+            Ok(Assignment::Expr(Expr::Negative(Box::new(Expr::Term(
+                Term::Factor(Factor::Variable("a".to_string()))
+            )))))
+        )
+    }
+
+    #[test]
+    fn test_parser_double_negative_expr() {
+        assert_eq!(
+            parse_assignment(&[Token::Minus, Token::Minus, Token::Variable("a".to_string()),]),
+            Err(CalcError::InvalidExpression)
+        )
+    }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -55,6 +55,12 @@ pub fn parse_expr(tokens: &[Token]) -> Result<Expr, CalcError> {
 
     // If the first token is a minus, this is a negative
     if let Some((_, &Token::Minus)) = it.peek() {
+        // avoid double negative expressions
+        it.next();
+        if let Some((_, &Token::Minus)) = it.peek() {
+            return Err(CalcError::InvalidExpression);
+        }
+
         return Ok(Expr::Negative(Box::new(parse_expr(&tokens[1..])?)));
     }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -15,6 +15,7 @@ pub enum Expr {
     Sum(Box<Expr>, Term),
     Subtract(Box<Expr>, Term),
     Term(Term),
+    Negative(Box<Expr>),
 }
 
 #[derive(Debug, PartialEq)]
@@ -29,7 +30,6 @@ pub enum Factor {
     Number(BigUint),
     Variable(String),
     Parenthesis(Box<Expr>),
-    Negative(Box<Factor>),
 }
 
 pub fn parse_assignment(tokens: &[Token]) -> Result<Assignment, CalcError> {
@@ -51,7 +51,12 @@ pub fn parse_assignment(tokens: &[Token]) -> Result<Assignment, CalcError> {
 }
 
 pub fn parse_expr(tokens: &[Token]) -> Result<Expr, CalcError> {
-    let mut it = tokens.iter().enumerate();
+    let mut it = tokens.iter().enumerate().peekable();
+
+    // If the first token is a minus, this is a negative
+    if let Some((_, &Token::Minus)) = it.peek() {
+        return Ok(Expr::Negative(Box::new(parse_expr(&tokens[1..])?)));
+    }
 
     while let Some((index, token)) = it.next() {
         match token {
@@ -123,7 +128,7 @@ fn parse_factor(tokens: &[Token]) -> Result<Factor, CalcError> {
         Some(Token::ResultVariable) if it.next().is_none() => {
             Ok(Factor::Variable(RES_VAR.to_string()))
         }
-        Some(Token::Minus) => Ok(Factor::Negative(Box::from(parse_factor(&tokens[1..])?))),
+        // Some(Token::Minus) => Ok(Factor::Negative(Box::from(parse_factor(&tokens[1..])?))),
         Some(Token::LeftPar) => {
             if let Some(Token::RightPar) = it.last() {
                 Ok(Factor::Parenthesis(Box::from(parse_expr(


### PR DESCRIPTION
Resolves #13

Changed the grammar so that negative numbers are handled as negative expressions instead of negative factors, so that checking for double negatives becomes easy. 